### PR TITLE
Fix Hexdocs domain in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ end
 ```
 
 ## Documentation
-Check [our documentation in Hexdocs](https://hexdocs.com/pgmq).
+Check [our documentation in Hexdocs](https://hexdocs.pm/pgmq).
 
 ## Usage with Broadway
 The [OffBroadwayPgmq](https://github.com/v0idpwn/off_broadway_pgmq) package


### PR DESCRIPTION
Link to Hexdocs should point at `.pm` domain, not `.com`. Fixed.